### PR TITLE
Bug Fix: removed hard-coded path to ssh config

### DIFF
--- a/kick_celery.py
+++ b/kick_celery.py
@@ -12,7 +12,7 @@ def main():
     args = parser.parse_args()
 
     ssh_config = paramiko.SSHConfig()
-    with open(os.path.expanduser('/root/.ssh/config')) as f:
+    with open(os.path.expanduser('~/.ssh/config')) as f:
         ssh_config.parse(f)
     ssh_params = ssh_config.lookup(args.environ)
 


### PR DESCRIPTION
This breaks when trying to run on a different Jenkins node, but using the current user's `.ssh/config` file does work correctly.
